### PR TITLE
support platform switch script

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "love.forte.tools"
-version = "0.0.8"
+version = "0.0.9"
 
 allprojects {
     repositories {

--- a/claude-code-skills-template/codex-agent-collaboration/SKILL.md
+++ b/claude-code-skills-template/codex-agent-collaboration/SKILL.md
@@ -21,15 +21,31 @@ The `codex-kkp-cli` is a Codex Agent CLI tool, allowing you to:
 ### Basic Syntax
 
 ```bash
+# Direct call with platform-specific executable
 executables/codex-kkp-cli-{platform} --cd=/absolute/path/to/project [options] "<task_description>"
 ```
 
-**Platform Variable**: `{platform}` should be automatically replaced based on the current system:
-- `macosx64` - macOS x86_64 (Intel)
-- `macosarm64` - macOS ARM64 (Apple Silicon)
+Where `{platform}` is one of:
+- `macosx64` - macOS Intel (x86_64)
+- `macosarm64` - macOS Apple Silicon (ARM64)
 - `linuxx64` - Linux x86_64
 - `linuxarm64` - Linux ARM64
 - `mingwx64` - Windows x86_64
+
+**Platform Auto-Detection Helper**: A platform detection script is provided to help identify your current platform:
+
+> On Windows, Just use mingwx64 platform directly, no need to use script detection.
+
+```bash
+# Unix/Linux/macOS
+codex-kkp-cli-platform
+# Outputs: macosx64, macosarm64, linuxx64, or linuxarm64
+```
+
+### communication
+
+This is AI-to-AI communication between You and Codex. PRIORITIZE ACCURACY AND PRECISION over human readability.
+Use structured data, exact technical terms, full paths, and precise details. NO conversational formatting needed.
 
 ### Required Parameters
 

--- a/claude-code-skills-template/codex-agent-collaboration/codex-kkp-cli-platform
+++ b/claude-code-skills-template/codex-agent-collaboration/codex-kkp-cli-platform
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Platform detection script for codex-kkp-cli
+# Outputs one of: macosx64, macosarm64, linuxx64, linuxarm64, mingwx64
+
+set -e
+
+# Detect OS
+case "$(uname -s)" in
+    Linux*)
+        os="linux"
+        ;;
+    Darwin*)
+        os="macos"
+        ;;
+    *)
+        echo "Error: Unsupported operating system: $(uname -s)" >&2
+        exit 1
+        ;;
+esac
+
+# Detect architecture
+case "$(uname -m)" in
+    x86_64|amd64)
+        arch="x64"
+        ;;
+    arm64|aarch64)
+        arch="arm64"
+        ;;
+    *)
+        echo "Error: Unsupported architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+# Output platform identifier
+echo "${os}${arch}"

--- a/claude-code-skills-template/codex-agent-collaboration/examples.md
+++ b/claude-code-skills-template/codex-agent-collaboration/examples.md
@@ -2,6 +2,20 @@
 
 This document provides examples of using the Codex CLI for various tasks.
 
+**Note:** All examples use platform-specific executables (e.g., `codex-kkp-cli-macosx64`). You can auto-detect your platform using the detection scripts:
+
+```bash
+# Unix/Linux/macOS
+PLATFORM=$(./executables/codex-kkp-cli)
+# Then use: executables/codex-kkp-cli-${PLATFORM}
+
+# Windows (PowerShell)
+$platform = .\executables\codex-kkp-cli.ps1
+# Then use: executables\codex-kkp-cli-$platform
+```
+
+For brevity, examples below use `codex-kkp-cli-{platform}` as a placeholder. Replace with your actual platform executable.
+
 ## Basic Examples
 
 ### Simple Task
@@ -27,31 +41,31 @@ executables/codex-kkp-cli-{platform} --cd=/path/to/project --full-auto --sandbox
 ### With Image Input
 
 ```bash
-executables/codex-kkp-cli-{platform} --cd=/path/to/project --image=/path/to/screenshot.png "Implement the UI shown in this design"
+executables/codex-kkp-cli --cd=/path/to/project --image=/path/to/screenshot.png "Implement the UI shown in this design"
 ```
 
 ### Multiple Images
 
 ```bash
-executables/codex-kkp-cli-{platform} --cd=/path/to/project --image=/path/to/design1.png --image=/path/to/design2.png "Compare these two designs and implement the better approach"
+executables/codex-kkp-cli --cd=/path/to/project --image=/path/to/design1.png --image=/path/to/design2.png "Compare these two designs and implement the better approach"
 ```
 
 ### Full Event Output
 
 ```bash
-executables/codex-kkp-cli-{platform} --cd=/path/to/project --full "Refactor the authentication module"
+executables/codex-kkp-cli --cd=/path/to/project --full "Refactor the authentication module"
 ```
 
 ### Save Last Message to File
 
 ```bash
-executables/codex-kkp-cli-{platform} --cd=/path/to/project --output-last-message=/tmp/codex-response.txt "Generate API documentation"
+executables/codex-kkp-cli --cd=/path/to/project --output-last-message=/tmp/codex-response.txt "Generate API documentation"
 ```
 
 ### Structured Output with Schema
 
 ```bash
-executables/codex-kkp-cli-{platform} --cd=/path/to/project --output-schema=/path/to/schema.json "Extract all function signatures from this module"
+executables/codex-kkp-cli --cd=/path/to/project --output-schema=/path/to/schema.json "Extract all function signatures from this module"
 ```
 
 ### With Git Repository Check
@@ -60,5 +74,5 @@ By default, Git repository check is skipped (`--skip-git-repo-check=true`).
 To enable Git check (e.g., for ensuring clean working directory):
 
 ```bash
-executables/codex-kkp-cli-{platform} --cd=/path/to/project --skip-git-repo-check=false "Analyze uncommitted changes"
+executables/codex-kkp-cli --cd=/path/to/project --skip-git-repo-check=false "Analyze uncommitted changes"
 ```


### PR DESCRIPTION
增加一个 codex-kkp-cli-platform 在 skills 中，支持通过脚本获取当前系统应该选择哪个平台，避免 CC 老是选择到错误的CPU架构（比如在 Intel MAC 系统上喜欢选 `macosarm64`）